### PR TITLE
Additional manual enrolment method

### DIFF
--- a/classes/enrol_form.php
+++ b/classes/enrol_form.php
@@ -1,0 +1,64 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package local_commerce
+ * @author Andrew Hancox <andrewdchancox@googlemail.com>
+ * @author Open Source Learning <enquiries@opensourcelearning.co.uk>
+ * @link https://opensourcelearning.co.uk
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright 2021, Andrew Hancox
+ */
+
+namespace enrol_autoenrol;
+
+use moodleform;
+
+require_once("$CFG->libdir/formslib.php");
+
+class enrol_form extends moodleform {
+    protected $instance;
+
+    /**
+     * Overriding this function to get unique form id for multiple self enrolments.
+     *
+     * @return string form identifier
+     */
+    protected function get_form_identifier() {
+        $formid = $this->_customdata->id.'_'.get_class($this);
+        return $formid;
+    }
+
+    public function definition() {
+        $mform = $this->_form;
+        $instance = $this->_customdata;
+        $this->instance = $instance;
+        $plugin = enrol_get_plugin('autoenrol');
+
+        $heading = $plugin->get_instance_name($instance);
+        $mform->addElement('header', 'autoenrolheader', $heading);
+
+        $this->add_action_buttons(false, get_string('enrolme', 'enrol_autoenrol'));
+
+        $mform->addElement('hidden', 'id');
+        $mform->setType('id', PARAM_INT);
+        $mform->setDefault('id', $instance->courseid);
+
+        $mform->addElement('hidden', 'instance');
+        $mform->setType('instance', PARAM_INT);
+        $mform->setDefault('instance', $instance->id);
+    }
+}

--- a/edit_form.php
+++ b/edit_form.php
@@ -373,7 +373,8 @@ class enrol_autoenrol_edit_form extends moodleform {
      */
     protected function get_enrolmethod_options() {
         $options = array( 0 => get_string('m_course', 'enrol_autoenrol'),
-                          1 => get_string('m_site', 'enrol_autoenrol'));
+                          1 => get_string('m_site', 'enrol_autoenrol'),
+                          2 => get_string('m_confirmation', 'enrol_autoenrol'));
         return $options;
     }
 

--- a/lang/en/enrol_autoenrol.php
+++ b/lang/en/enrol_autoenrol.php
@@ -40,6 +40,7 @@ The following placeholders may be included in the message:
 * Link to user\'s profile page {$a->profileurl}
 * User email {$a->email}
 * User fullname {$a->fullname}';
+$string['enrolme'] = 'Enrol me';
 $string['general'] = 'General';
 $string['filtering'] = 'User Filtering';
 
@@ -56,6 +57,7 @@ $string['role_help'] = 'Power users can use this setting to change the permissio
 
 $string['method'] = 'Enrol When';
 $string['m_site'] = 'Logging into Site';
+$string['m_confirmation'] = 'Confirmation on enrol screen';
 $string['m_course'] = 'Loading the Course';
 $string['method_help'] = 'Power users can use this setting to change the plugin\'s behaviour so that users are enrolled to the course upon logging in rather than waiting for them to access the course. This is helpful for courses which should be visible on a users "my courses" list by default.';
 


### PR DESCRIPTION
A client had a scenario where they wanted all of your filtering, auto-unenrolment, auto grouping etc. but wanted the user to have to make a final manual confirmation that they wish to enrol on the course.