### PR TITLE
Do not prefix custom name with auto

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -350,7 +350,7 @@ class enrol_autoenrol_plugin extends enrol_plugin {
             $enrol = $this->get_name();
             return get_string('pluginname', 'enrol_'.$enrol) . $role;
         } else {
-            return get_string('auto', 'enrol_autoenrol') . ' ' . format_string($instance->name);
+            return format_string($instance->name);
         }
     }
 


### PR DESCRIPTION
If you allow users to supply a custom name for the enrolment instance it seems odd to prefix it with 'auto'.