### PR TITLE
Logged in user is falsely flagged as guest preventing autoenrolment o…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -180,7 +180,7 @@ class enrol_autoenrol_plugin extends enrol_plugin {
     public function enrol_allowed(stdClass $instance, $user) {
         global $DB;
 
-        if (isguestuser()) {
+        if (isguestuser($user)) {
             // Can not enrol guest!!
             return false;
         }


### PR DESCRIPTION
When you have an active session as a guest user and then login or create a real user account. The autoenrolment on login will not enrol the user because the session still contains the guest user object instead of the logged in user and this logged in user is not passed as argument to the `isguestuser()` method as argument. And the autoenrol therefor skips enrolling guest users.