### PR TITLE
MBS-8479: Add option to show welcome message on confirmation page

### DIFF
--- a/classes/enrol_form.php
+++ b/classes/enrol_form.php
@@ -75,6 +75,10 @@ class enrol_form extends moodleform {
         $heading = $plugin->get_instance_name($instance);
         $mform->addElement('header', 'autoenrolheader', $heading);
 
+        if (!empty($instance->customint2)) {
+            list($message) = welcomemessage::get_welcomemessage($instance);
+            $mform->addElement('html', format_text($message));
+        }
         $this->add_action_buttons(false, get_string('enrolme', 'enrol_autoenrol'));
 
         $mform->addElement('hidden', 'id');

--- a/classes/welcomemessage.php
+++ b/classes/welcomemessage.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Class to handle welcomemessage.
+ *
+ * @package     enrol_autoenrol
+ * @copyright   2023 ISB Bayern
+ * @author      Dr. Peter Mayer
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace enrol_autoenrol;
+
+/**
+ * Class to handle welcomemessage.
+ *
+ * @package     enrol_autoenrol
+ * @copyright   2023 ISB Bayern
+ * @author      Dr. Peter Mayer
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class welcomemessage {
+
+    /**
+     * Get the welcomemessage.
+     *
+     * @param object $instance enrol instance
+     * @return array ["messagetext", [message context]]
+     */
+    public static function get_welcomemessage(object $instance): array {
+        global $CFG, $DB, $USER;
+
+        $course = $DB->get_record('course', ['id' => $instance->courseid], '*', MUST_EXIST);
+        $context = \context_course::instance($course->id);
+
+        $a = new \stdClass();
+        $a->coursename = format_string($course->fullname, true, ['context' => $context]);
+        $a->profileurl = new \moodle_url($CFG->wwwroot . '/user/view.php', ['id' => $USER->id, 'course' => $course->id]);
+        $a->link = course_get_url($course)->out();
+
+        $message = $instance->customtext1;
+
+        $key = ['{$a->coursename}', '{$a->profileurl}', '{$a->link}', '{$a->fullname}', '{$a->email}'];
+        $value = [$a->coursename, $a->profileurl, $a->link, fullname($USER), $USER->email];
+
+        return [str_replace($key, $value, $message), $a];
+    }
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -275,5 +275,9 @@ function xmldb_enrol_autoenrol_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022062000, 'enrol', 'autoenrol');
     }
 
+    if ($oldversion < 2023120500) {
+        upgrade_plugin_savepoint(true, 2023120500, 'enrol', 'autoenrol');
+    }
+
     return true;
 }

--- a/lang/en/enrol_autoenrol.php
+++ b/lang/en/enrol_autoenrol.php
@@ -57,6 +57,8 @@ $string['welcometocoursetext'] = 'Welcome to {$a->coursename}!
 If you have not done so already, you should edit your profile page so that we can learn more about you:
 
   {$a->profileurl}';
+$string['showwelcomemessageonconfirmationpage'] = 'Show the welcomemessage on confirmation page.';
+$string['showwelcomemessageonconfirmationpage_help'] = 'Default value for new autoenrol instances to also show the welcome message on the enrol confirmation page.';
 
 $string['role'] = 'Default assigned role';
 $string['role_help'] = 'Power users can use this setting to change the permission level at which users are enrolled.';

--- a/settings.php
+++ b/settings.php
@@ -151,6 +151,15 @@ if ($ADMIN->fulltree) {
         );
     }
 
+    $settings->add(
+        new admin_setting_configcheckbox(
+            'enrol_autoenrol/showwelcomemessageonconfirmationpage',
+            get_string('showwelcomemessageonconfirmationpage', 'enrol_autoenrol'),
+            get_string('showwelcomemessageonconfirmationpage_help', 'enrol_autoenrol'),
+            0
+        )
+    );
+
     if (!during_initial_install()) {
         $pluginmanager = \core_plugin_manager::instance();
         $availabilities = array_keys($pluginmanager->get_enabled_plugins('availability'));

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022062000;
+$plugin->version = 2023120500;
 $plugin->requires = 2018051700.00;      // Requires this Moodle version (3.5).
 $plugin->release = '2.3.9';             // Plugin release.
 $plugin->component = 'enrol_autoenrol'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
I added a new feature to optionally show the welcome message also on confirmation page.

Background:
Our client's lawyers required that the terms of use / welcome message must also be available on the enrollment confirmation page. In order for the registration to be considered as acceptance of the terms of use.