### PR TITLE
Fix #70 - Adds option to unsuspend user enrolments that match filter rules

### DIFF
--- a/lang/en/enrol_autoenrol.php
+++ b/lang/en/enrol_autoenrol.php
@@ -25,6 +25,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['allowunsuspend'] = 'Allow unsuspension';
+$string['allowunsuspend_desc'] = 'When set to Yes the plugin will unsuspend a previously suspended user enrolment if that user matches the filtering rules.';
 $string['alwaysenrol'] = 'Auto enrol already enrolled user';
 $string['alwaysenrol_help'] = 'When set to Yes the plugins will always enrol users, even if they already have access to the course through another method.';
 $string['auto'] = 'Auto';

--- a/lib.php
+++ b/lib.php
@@ -431,7 +431,18 @@ class enrol_autoenrol_plugin extends enrol_plugin {
                         }
                     }
                 } else {
-                    // If rule is verified update user group enrolments.
+                    // If rule is verified check for suspended enrolments.
+                    if ($this->get_config('allowunsuspend')) {
+                        // Check if enrolment is suspended.
+                        foreach ($userenrolments as $userenrolment) {
+                            if ($userenrolment->enrolid == $instance->id) {
+                                if ($userenrolment->status == ENROL_USER_SUSPENDED) {
+                                    $this->update_user_enrol($instance, $user->id, ENROL_USER_ACTIVE);
+                                }
+                            }
+                        }
+                    }
+                    // Update user group enrolments.
                     $this->process_group($instance, $user);
                 }
             }

--- a/settings.php
+++ b/settings.php
@@ -51,6 +51,10 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configselect('enrol_autoenrol/selfunenrol',
         get_string('selfunenrol', 'enrol_autoenrol'), get_string('selfunenrol_desc', 'enrol_autoenrol'), 1, $options));
 
+    $options = [1  => get_string('yes'), 0 => get_string('no')];
+    $settings->add(new admin_setting_configselect('enrol_autoenrol/allowunsuspend',
+        get_string('allowunsuspend', 'enrol_autoenrol'), get_string('allowunsuspend_desc', 'enrol_autoenrol'), 0, $options));
+
     if (!during_initial_install()) {
         $options = get_default_enrol_roles(context_system::instance());
         $student = get_archetype_roles('student');


### PR DESCRIPTION
Setting defaults to "No" as that matches existing behaviour.